### PR TITLE
Move swarm deploy to action to prevent depth error

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -2,29 +2,32 @@ name: Docker Build
 description: Build docker images
 
 inputs:
+  version:
+    description: Version of the image
+    required: true
   container_repository:
     description: The container repository to store the image
     required: false
     default: 'nexus'
+  dockernexus_username:
+    description: The username to use to authenticate to the docker nexus
+    required: true
+  dockernexus_token:
+    description: The token to use to authenticate to the docker nexus
+    required: true
+  github_token:
+    description: The token to use to authenticate to the github
+    required: true
 
 outputs:
   docker_repository:
     description: The docker repository used
     value: ${{ env.DOCKER_REPOSITORY }}
-  version:
-    description: The image version
-    value: ${{ steps.version.outputs.version }}
 
 runs:
   using: composite
 
   steps:
-
-    - name: Extract version
-      id: version
-      uses: ./.github/actions/anemone-version
-      with:
-        branch_name: ${{ github.base_ref }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -35,8 +38,8 @@ runs:
         echo "REGISTRY=nexus.playtomic.io" >> $GITHUB_ENV
         echo "IMAGE=nexus.playtomic.io/${{ github.event.repository.name }}" >> $GITHUB_ENV
         echo "DOCKER_REPOSITORY=nexus.playtomic.io" >> $GITHUB_ENV
-        echo "DOCKER_USERNAME=${{ secrets.dockernexus_username }}" >> $GITHUB_ENV
-        echo "DOCKER_PASSWORD=${{ secrets.dockernexus_token }}" >> $GITHUB_ENV
+        echo "DOCKER_USERNAME=${{ inputs.dockernexus_username }}" >> $GITHUB_ENV
+        echo "DOCKER_PASSWORD=${{ inputs.dockernexus_token }}" >> $GITHUB_ENV
       shell: bash
 
     - name: GHCR environment
@@ -46,7 +49,7 @@ runs:
         echo "IMAGE=nexus.playtomic.io/${{ github.event.repository.name }}" >> $GITHUB_ENV
         echo "DOCKER_REPOSITORY=ghcr.io/${{ github.repository_owner }}" >> $GITHUB_ENV  
         echo "DOCKER_USERNAME=${{ github.repository_owner }}" >> $GITHUB_ENV
-        echo "DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+        echo "DOCKER_PASSWORD=${{ inputs.github_token }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Docker login
@@ -62,7 +65,7 @@ runs:
       with:
         images: ${{ env.IMAGE }}
         tags: |
-          type=raw,value=${{ steps.version.outputs.version }}
+          type=raw,value=${{ inputs.version }}
           type=raw,value=latest
 
     - name: Build and push

--- a/.github/actions/swarm-deploy/action.yml
+++ b/.github/actions/swarm-deploy/action.yml
@@ -1,0 +1,57 @@
+name: Swarm Deploy
+description: Deploy a service in the Swarm cluster
+
+inputs:
+  version:
+    description: The version of the image to be deployed
+    required: true
+  replicas:
+    description: The number of replicas to deploy
+    required: false
+    default: '2'
+  docker_repository:
+    description: The docker repository of the image
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Set common environment variables
+      run: |
+        echo "USE_DATADOG_AGENT=true" >> $GITHUB_ENV
+        echo "HEALTHCHECK_START_PERIOD=300s" >> $GITHUB_ENV         
+        echo "DEPLOY_ORDER=start-first" >> $GITHUB_ENV
+        echo "DOCKER_REPOSITORY=${{inputs.docker_repository}}" >> $GITHUB_ENV
+        echo "SERVICE_VERSION=${{inputs.version}}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set develop environment variables
+      if: ${{ github.ref_name == 'develop' }}
+      run: |
+        echo "SPRING_PROFILES_ACTIVE=develop" >> $GITHUB_ENV
+        echo "ENVIRONMENT=develop" >> $GITHUB_ENV
+        echo "REPLICAS=1" >> $GITHUB_ENV
+        echo "SERVICE_DOMAIN=$DOMAIN" >> $GITHUB_ENV
+        echo "JAVA_ENABLE_DEBUG=true" >> $GITHUB_ENV
+        echo "AWS_DOCKER_HOST=ec2-18-197-214-85.eu-central-1.compute.amazonaws.com" >> $GITHUB_ENV
+        echo "AWS_DOCKER_CERT_PATH=/home/github/.docker/machine/machines/awsdevelop/cert.pem" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set production environment variables
+      if: ${{ github.ref_name == 'master' || github.ref_name == 'main' }}
+      run: |
+        echo "SPRING_PROFILES_ACTIVE=amazon-pro" >> $GITHUB_ENV
+        echo "ENVIRONMENT=pro" >> $GITHUB_ENV
+        echo "REPLICAS=${{inputs.replicas}}" >> $GITHUB_ENV
+        echo "SERVICE_DOMAIN=$DOMAIN-pro" >> $GITHUB_ENV
+        echo "JAVA_ENABLE_DEBUG=null" >> $GITHUB_ENV
+        echo "AWS_DOCKER_HOST=ec2-52-28-129-63.eu-central-1.compute.amazonaws.com" >> $GITHUB_ENV
+        echo "AWS_DOCKER_CERT_PATH=/home/github/.docker/machine/machines/awspro/cert.pem" >> $GITHUB_ENV
+      shell: bash
+
+    - name: "Deployment to AWS - Docker Swarm ${{ env.ENVIRONMENT }}"
+      run: ssh -i /home/github/.docker/machine/machines/awsdevelop/cert.pem -f -L localhost:2374:/var/run/docker.sock ec2-user@${{env.AWS_DOCKER_HOST}} sleep 5; USE_DATADOG_AGENT=${{env.USE_DATADOG_AGENT}} DOCKER_REPOSITORY=${{env.DOCKER_REPOSITORY}} SPRING_PROFILES_ACTIVE=${{env.SPRING_PROFILES_ACTIVE}} JAVA_ENABLE_DEBUG=${{env.JAVA_ENABLE_DEBUG}} SERVICE_DOMAIN=${{env.SERVICE_DOMAIN}} REPLICAS=${{env.REPLICAS}} HEALTHCHECK_START_PERIOD=${{env.HEALTHCHECK_START_PERIOD}} DEPLOY_ORDER=${{env.DEPLOY_ORDER}} docker -Hlocalhost:2374 stack deploy ${{env.SERVICE_DOMAIN}} --with-registry-auth -c docker-compose.yml
+      shell: bash

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,24 +40,39 @@ jobs:
 
       - name: Build and Verify
         uses: syltek/workflows/.github/actions/maven-build@main
+        with:
+          java_version: ${{ inputs.java_version }}
+          nexus_user: ${{ secrets.nexus_user }}
+          nexus_password: ${{ secrets.nexus_password }}
+          branch: ${{ github.base_ref }}
+
+      - name: Extract version
+        id: version
+        uses: syltek/workflows/.github/actions/anemone-version@main
+        with:
+          branch_name: ${{ github.base_ref }}sion
 
       - name: Docker build
         id: docker-build
         uses: syltek/workflows/.github/actions/docker-build@main
         with:
           version: ${{ steps.version.outputs.version }}
+          dockernexus_username: ${{ secrets.dockernexus_username }}
+          dockernexus_token: ${{ secrets.dockernexus_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
-      version: ${{ steps.docker-build.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
       docker_repository: ${{ steps.docker-build.outputs.docker_repository }}
 
-  deploy:
-
-    runs-on: self-hosted
+  self-hosted-deploy:
     needs: build
+    runs-on: self-hosted
+    env:
+      DOMAIN: 'anemone'
 
     steps:
-      - uses: syltek/workflows/.github/workflows/self-hosted-runner-publish.yml@main
+      - uses: syltek/workflows/.github/actions/swarm-deploy@main
         with:
           version: ${{ needs.build.outputs.version }}
           replicas: ${{ inputs.replicas }}


### PR DESCRIPTION
We cannot reuse a workflow inside a reused workflow because Github doesn't allow it, so we have to move to a composite action.
Also fixes errors in docker-build action with secrets and inputs